### PR TITLE
[eventmaker] Parse time issue

### DIFF
--- a/eventmaker/eventmaker.py
+++ b/eventmaker/eventmaker.py
@@ -309,7 +309,7 @@ class EventMaker():
                     return None  # issue with the user's input
             else:
                 return None  # something went wrong in user's input
-            return start_time
+        return start_time
 
     @commands.group(pass_context=True)
     @checks.admin_or_permissions(manage_server=True)


### PR DESCRIPTION
Time wasn't being completely added up at time of creation. It stopped after first time. I.e., 1d 2h 4m would only cause the event to be created for 1 day ahead instead of the full time specified.