### PR TITLE
[V3 Eventmaker] Increased timeout

### DIFF
--- a/eventmaker/eventmaker.py
+++ b/eventmaker/eventmaker.py
@@ -143,7 +143,7 @@ class EventMaker:
             return msg.author == author
         
         try:
-            msg = await self.bot.wait_for("message", check=same_author_check, timeout=30)
+            msg = await self.bot.wait_for("message", check=same_author_check, timeout=60)
         except asyncio.TimeoutError:
             await ctx.send("No name provided!")
             return
@@ -154,7 +154,7 @@ class EventMaker:
             "place (valid units are w, d, h, m, s): "
         )
         try:
-            msg = await self.bot.wait_for("message", check=same_author_check, timeout=30)
+            msg = await self.bot.wait_for("message", check=same_author_check, timeout=60)
         except asyncio.TimeoutError:
             await ctx.send("No start time provided!")
             return
@@ -165,7 +165,7 @@ class EventMaker:
         msg = None
         await ctx.send("Enter a description for the event: ")
         try:
-            msg = await self.bot.wait_for("message", check=same_author_check, timeout=30)
+            msg = await self.bot.wait_for("message", check=same_author_check, timeout=60)
         except asyncio.TimeoutError:
             await ctx.send("No description provided!")
             return


### PR DESCRIPTION
Some guilds aren't able to type out the event info/time within the 30 second allotment, increased to 60.