### PR TITLE
Fix breaking change

### DIFF
--- a/lockdown/info.json
+++ b/lockdown/info.json
@@ -1,6 +1,5 @@
 {
     "author" : ["palmtree5"],
-    "bot_version": "3.0.0b14",
     "install_msg" : "[p]help Lockdown to see commands, as well as setup instructions.",
     "name" : "Lockdown",
     "disabled" : false,

--- a/lockdown/info.json
+++ b/lockdown/info.json
@@ -1,5 +1,6 @@
 {
     "author" : ["palmtree5"],
+    "bot_version": "3.0.0b14",
     "install_msg" : "[p]help Lockdown to see commands, as well as setup instructions.",
     "name" : "Lockdown",
     "disabled" : false,

--- a/lockdown/lockdown.py
+++ b/lockdown/lockdown.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 from redbot.core import Config, checks
-from redbot.core.context import commands
+from redbot.core import commands
 from redbot.core.utils.chat_formatting import box
 
 


### PR DESCRIPTION
This fix the lockdown cog to work with the most recent Red versions, with the breaking change of `redbot.core.commands`.