### PR TITLE
[V3] Corrects the commands import line in the tweets cog

### DIFF
--- a/tweets/menus.py
+++ b/tweets/menus.py
@@ -1,6 +1,6 @@
 import asyncio
 import discord
-from redbot.core.context import commands
+from redbot.core import commands
 from redbot.core.utils.embed import randomize_colour
 
 

--- a/tweets/tweets.py
+++ b/tweets/tweets.py
@@ -4,9 +4,9 @@ from random import choice as randchoice
 import discord
 from redbot.core import commands
 from peony import PeonyClient
-from redbot.core import Config, checks
+from redbot.core import Config, checks, commands
 from redbot.core.bot import Red
-from redbot.core.context import commands
+
 
 from .errors import NoClientException
 from .menus import tweet_menu


### PR DESCRIPTION
Currently the `tweets` cog will not load after installing. This is due to the cog attempting to import `commands` from a non-existent module. Presently if you attempt to load the cog, you will be greeted with the following error:

```python
Exception during loading of cog
Traceback (most recent call last):
  File "/etc/redbot/.pyenv/versions/3.7.0/lib/python3.7/site-packages/redbot/core/core_commands.py", line 95, in _load
    await bot.load_extension(spec)
  File "/etc/redbot/.pyenv/versions/3.7.0/lib/python3.7/site-packages/redbot/core/bot.py", line 220, in load_extension
    lib = spec.loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 407, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 907, in load_module
  File "<frozen importlib._bootstrap_external>", line 732, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/etc/redbot/pal9000/cogs/CogManager/cogs/tweets/__init__.py", line 1, in <module>
    from .tweets import Tweets
  File "/etc/redbot/pal9000/cogs/CogManager/cogs/tweets/tweets.py", line 9, in <module>
    from redbot.core.context import commands
ModuleNotFoundError: No module named 'redbot.core.context'
```

I've removed the `from redbot.core.context import commands` lines and replaced them with `from redbot.core import commands`. After testing the cog loads after being installed.