### PR TITLE
Use relative imports in cog packages

### DIFF
--- a/mcsvr/mcsvr.py
+++ b/mcsvr/mcsvr.py
@@ -8,7 +8,7 @@ from redbot.core import Config, checks, commands
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator
 
-from mcsvr.helpers import check_server, get_server_embed, is_valid_ip, get_server_string
+from .helpers import check_server, get_server_embed, is_valid_ip, get_server_string
 
 log = logging.getLogger("red.mcsvr")
 

--- a/reddit/helpers.py
+++ b/reddit/helpers.py
@@ -5,7 +5,7 @@ import discord
 from redbot.core.utils.embed import randomize_colour
 import logging
 
-from reddit.errors import RedditAPIError, AccessForbiddenError, NotFoundError
+from .errors import RedditAPIError, AccessForbiddenError, NotFoundError
 
 
 async def make_request(

--- a/reddit/reddit.py
+++ b/reddit/reddit.py
@@ -11,7 +11,7 @@ from redbot.core.utils.chat_formatting import error
 from redbot.core.utils.embed import randomize_colour
 from redbot.core.i18n import Translator
 
-from reddit.menus import post_menu
+from .menus import post_menu
 from .errors import NoAccessTokenError, RedditAPIError, NotFoundError, AccessForbiddenError
 from .helpers import make_request, private_only
 


### PR DESCRIPTION
A future update to Red will mean doing an absolute import starting with your cog package's name will be unsupported. It wasn't really intended to work in the first place :grimacing:.

The change which will break absolute imports is in Cog-Creators/Red-DiscordBot#2446. It's an unintended side effect, but I don't see a reason to support them going forward if we can help people migrate away from using them :smiley:.