### PR TITLE
Migrate from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/compile_all.yaml
+++ b/.github/workflows/compile_all.yaml
@@ -1,0 +1,19 @@
+name: Compile all
+on:
+  - push
+  - pull_request
+
+jobs:
+  compile_all:
+    name: Compile all
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+      - name: Install requirements
+        run: python -m pip install -Ur requirements.txt
+      - name: Compile all
+        run: python -m compileall ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-  - "3.5.2"
-install:
-  - pip install -r requirements.txt
-script: python -m compileall ./
-cache: pip
-notifications:
-  email: false


### PR DESCRIPTION
Travis CI stopped providing their service to open-source community for free. There technically is a a way to request special OSS credits but they are not renewable and this whole process needs to be repeated and is generally very annoying. GitHub Actions are superior unless you have special requirements (which this repository doesn't) anyway.